### PR TITLE
feat: manual corner editor + packaging fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     
     strategy:
       matrix:
-        node-version: [18, 20, 22]
+        node-version: [20, 22, 24]
     
     steps:
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -95,6 +95,34 @@ if (extracted.success) {
 }
 ```
 
+### Manual Corner Adjustment UI (New)
+
+Use the built-in corner editor to let users drag corners on mobile and desktop,
+then pass the confirmed corners into extraction.
+
+```js
+import { createCornerEditor, extractDocument } from 'scanic';
+
+const editor = createCornerEditor({
+  container: document.getElementById('editorHost'),
+  image: imageElement,
+  corners: detectedCorners, // optional: defaults to an inset quad
+  magnifier: {
+    zoom: 2,
+    size: 110
+  },
+  nudges: {
+    enabled: true,
+    steps: [1, 5]
+  },
+  onConfirm: async (corners) => {
+    const extracted = await extractDocument(imageElement, corners, { output: 'canvas' });
+    document.getElementById('output').appendChild(extracted.output);
+    editor.destroy();
+  }
+});
+```
+
 ### Optimized Usage (Recommended for Batch/Real-time)
 The `Scanner` class maintains a persistent WebAssembly instance, avoiding the overhead of re-initializing WASM for every scan.
 

--- a/demo.html
+++ b/demo.html
@@ -262,6 +262,16 @@
       height: auto;
       background: #eee;
     }
+
+    #cornerEditorHost {
+      width: 100%;
+      min-height: 320px;
+      background: #0b1220;
+      border-radius: 10px;
+      border: 1px solid var(--border);
+      overflow: hidden;
+      margin-top: 1rem;
+    }
   </style>
 </head>
 <body>
@@ -327,7 +337,11 @@
       <h2 id="resultTitle">✨ Result Preview</h2>
       <p id="resultSubtitle" class="result-subtitle">Select detect for corner preview, or extract for perspective crop.</p>
       <canvas id="staticCanvas"></canvas>
+      <div id="cornerEditorHost" class="hidden"></div>
       <div style="margin-top: 1rem;">
+        <button class="btn btn-secondary hidden" id="btnAdjustCorners">Adjust Corners</button>
+        <button class="btn btn-primary hidden" id="btnApplyCorners">Apply</button>
+        <button class="btn btn-secondary hidden" id="btnCancelCorners">Cancel</button>
         <button class="btn btn-secondary" id="btnDownload">Download PNG</button>
         <button class="btn btn-secondary" onclick="document.getElementById('extracted-container').classList.add('hidden')">Close</button>
       </div>
@@ -335,7 +349,7 @@
   </div>
 
   <script type="module">
-    import { Scanner, scanDocument } from './scanic.js';
+    import { Scanner, scanDocument, extractDocument, createCornerEditor } from './scanic.js';
 
     const scanner = new Scanner();
     let isLive = false;
@@ -360,8 +374,16 @@
     const staticModeHelp = document.getElementById('staticModeHelp');
     const resultTitle = document.getElementById('resultTitle');
     const resultSubtitle = document.getElementById('resultSubtitle');
+    const cornerEditorHost = document.getElementById('cornerEditorHost');
+    const btnAdjustCorners = document.getElementById('btnAdjustCorners');
+    const btnApplyCorners = document.getElementById('btnApplyCorners');
+    const btnCancelCorners = document.getElementById('btnCancelCorners');
 
     let staticMode = 'detect';
+    let activeCornerEditor = null;
+    let currentStaticImage = null;
+    let currentDetectedCorners = null;
+    const AUTO_EDITOR_CONFIDENCE_THRESHOLD = 0.6;
 
     const sampleImageFiles = [
       '25_2.jpg',
@@ -471,6 +493,82 @@
       targetCtx.restore();
     }
 
+    function closeCornerEditor() {
+      if (activeCornerEditor) {
+        activeCornerEditor.destroy();
+        activeCornerEditor = null;
+      }
+      cornerEditorHost.innerHTML = '';
+      cornerEditorHost.classList.add('hidden');
+      btnApplyCorners.classList.add('hidden');
+      btnCancelCorners.classList.add('hidden');
+    }
+
+    function showCanvasView() {
+      closeCornerEditor();
+      staticCanvas.classList.remove('hidden');
+      btnDownload.classList.remove('hidden');
+    }
+
+    async function applyManualCorners(image, corners) {
+      const extracted = await extractDocument(image, corners, { output: 'canvas' });
+      if (!extracted.success || !extracted.output) {
+        throw new Error(extracted.message || 'Manual extraction failed');
+      }
+
+      const staticCtx = staticCanvas.getContext('2d');
+      staticCanvas.width = extracted.output.width;
+      staticCanvas.height = extracted.output.height;
+      staticCtx.drawImage(extracted.output, 0, 0);
+
+      resultTitle.textContent = '✨ Manually Adjusted Extraction';
+      resultSubtitle.textContent = 'Corners were adjusted and applied successfully.';
+      statStatus.textContent = 'Manual correction applied';
+      showCanvasView();
+      extractedContainer.scrollIntoView({ behavior: 'smooth' });
+    }
+
+    function openCornerEditorForImage(image, corners, reasonLabel = 'Adjust corners') {
+      closeCornerEditor();
+
+      staticCanvas.classList.add('hidden');
+      btnDownload.classList.add('hidden');
+      cornerEditorHost.classList.remove('hidden');
+      btnApplyCorners.classList.remove('hidden');
+      btnCancelCorners.classList.remove('hidden');
+
+      resultTitle.textContent = '🎯 Manual Corner Adjustment';
+      resultSubtitle.textContent = `${reasonLabel}. Drag corner handles, then tap Apply.`;
+
+      activeCornerEditor = createCornerEditor({
+        container: cornerEditorHost,
+        image,
+        corners,
+        nudges: {
+          enabled: true,
+          steps: [1, 5]
+        },
+        magnifier: {
+          enabled: true,
+          zoom: 2,
+          size: 110
+        },
+        onConfirm: async (nextCorners) => {
+          try {
+            currentDetectedCorners = nextCorners;
+            await applyManualCorners(image, nextCorners);
+          } catch (err) {
+            console.error(err);
+            statStatus.textContent = 'Manual extraction failed';
+          }
+        },
+        onCancel: () => {
+          resultSubtitle.textContent = 'Manual adjustment canceled.';
+          showCanvasView();
+        }
+      });
+    }
+
     // --- Static Scanner Logic ---
     dropZone.onclick = () => fileInput.click();
     fileInput.onchange = (e) => processFile(e.target.files[0]);
@@ -512,12 +610,18 @@
     }
 
     async function processImage(img) {
+      closeCornerEditor();
       extractedContainer.classList.remove('hidden');
       statStatus.textContent = 'Processing static image...';
+      currentStaticImage = img;
+      currentDetectedCorners = null;
+      btnAdjustCorners.classList.add('hidden');
 
       const result = await scanDocument(img, { mode: staticMode });
       if (result.success) {
         const staticCtx = staticCanvas.getContext('2d');
+        currentDetectedCorners = result.corners || null;
+        btnAdjustCorners.classList.toggle('hidden', !currentDetectedCorners);
 
         if (staticMode === 'detect') {
           staticCanvas.width = img.width;
@@ -529,12 +633,25 @@
           resultTitle.textContent = '📐 Detection Preview';
           const confidenceText = result.confidence != null ? `Confidence ${(result.confidence * 100).toFixed(1)}%` : 'Corners detected';
           resultSubtitle.textContent = `${confidenceText}. Switch to Extract mode to crop the document.`;
+
+          if (result.corners && result.confidence != null && result.confidence < AUTO_EDITOR_CONFIDENCE_THRESHOLD) {
+            openCornerEditorForImage(img, result.corners, `Low confidence (${(result.confidence * 100).toFixed(1)}%)`);
+          } else {
+            showCanvasView();
+          }
         } else {
           staticCanvas.width = result.output.width;
           staticCanvas.height = result.output.height;
           staticCtx.drawImage(result.output, 0, 0);
           resultTitle.textContent = '✨ Extracted Document';
-          resultSubtitle.textContent = 'Perspective-corrected output ready to download.';
+          const confidenceText = result.confidence != null ? `Confidence ${(result.confidence * 100).toFixed(1)}%. ` : '';
+          resultSubtitle.textContent = `${confidenceText}Perspective-corrected output ready to download.`;
+
+          if (result.corners && result.confidence != null && result.confidence < AUTO_EDITOR_CONFIDENCE_THRESHOLD) {
+            openCornerEditorForImage(img, result.corners, `Low confidence (${(result.confidence * 100).toFixed(1)}%)`);
+          } else {
+            showCanvasView();
+          }
         }
 
         extractedContainer.scrollIntoView({ behavior: 'smooth' });
@@ -543,8 +660,24 @@
         resultTitle.textContent = '⚠️ No Document Detected';
         resultSubtitle.textContent = 'Try a clearer image or switch mode.';
         statStatus.textContent = 'No document detected';
+        showCanvasView();
       }
     }
+
+    btnAdjustCorners.onclick = () => {
+      if (!currentStaticImage || !currentDetectedCorners) return;
+      openCornerEditorForImage(currentStaticImage, currentDetectedCorners, 'Manual adjustment requested');
+    };
+
+    btnApplyCorners.onclick = () => {
+      if (!activeCornerEditor) return;
+      activeCornerEditor.confirm();
+    };
+
+    btnCancelCorners.onclick = () => {
+      if (!activeCornerEditor) return;
+      activeCornerEditor.cancel();
+    };
 
     // --- Live Scanner Logic ---
     btnStart.onclick = async () => {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Modern document scanner in pure JavaScript and Wasm",
   "type": "module",
   "sideEffects": false,
+  "engines": {
+    "node": ">=20"
+  },
   "main": "dist/scanic.umd.cjs",
   "module": "dist/scanic.js",
   "types": "src/scanic.d.ts",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.8",
   "description": "Modern document scanner in pure JavaScript and Wasm",
   "type": "module",
+  "sideEffects": false,
   "main": "dist/scanic.umd.cjs",
   "module": "dist/scanic.js",
   "types": "src/scanic.d.ts",

--- a/src/cornerEditor.js
+++ b/src/cornerEditor.js
@@ -1,0 +1,821 @@
+function cloneCorners(corners) {
+  return {
+    topLeft: { x: corners.topLeft.x, y: corners.topLeft.y },
+    topRight: { x: corners.topRight.x, y: corners.topRight.y },
+    bottomRight: { x: corners.bottomRight.x, y: corners.bottomRight.y },
+    bottomLeft: { x: corners.bottomLeft.x, y: corners.bottomLeft.y }
+  };
+}
+
+function pointDistance(a, b) {
+  return Math.hypot(a.x - b.x, a.y - b.y);
+}
+
+function cornersAreFiniteAndDistinct(corners, minDistance = 4) {
+  const points = [corners?.topLeft, corners?.topRight, corners?.bottomRight, corners?.bottomLeft];
+  if (points.some((p) => !p || !Number.isFinite(p.x) || !Number.isFinite(p.y))) {
+    return false;
+  }
+
+  for (let i = 0; i < points.length; i++) {
+    for (let j = i + 1; j < points.length; j++) {
+      if (pointDistance(points[i], points[j]) < minDistance) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function isConvexQuadrilateral(corners) {
+  const points = [corners.topLeft, corners.topRight, corners.bottomRight, corners.bottomLeft];
+  const crossSigns = [];
+
+  for (let i = 0; i < points.length; i++) {
+    const p0 = points[i];
+    const p1 = points[(i + 1) % points.length];
+    const p2 = points[(i + 2) % points.length];
+    const cross = (p1.x - p0.x) * (p2.y - p1.y) - (p1.y - p0.y) * (p2.x - p1.x);
+    if (Math.abs(cross) < 1e-6) continue;
+    crossSigns.push(Math.sign(cross));
+  }
+
+  if (crossSigns.length < 3) {
+    return false;
+  }
+
+  const firstSign = crossSigns[0];
+  return crossSigns.every((s) => s === firstSign);
+}
+
+function createDefaultCorners(imageWidth, imageHeight, insetRatio = 0.08) {
+  const inset = Math.max(8, Math.min(imageWidth, imageHeight) * insetRatio);
+  return {
+    topLeft: { x: inset, y: inset },
+    topRight: { x: imageWidth - inset, y: inset },
+    bottomRight: { x: imageWidth - inset, y: imageHeight - inset },
+    bottomLeft: { x: inset, y: imageHeight - inset }
+  };
+}
+
+function drawHandle(ctx, point, radius, color, stroke, lineWidth) {
+  ctx.beginPath();
+  ctx.arc(point.x, point.y, radius, 0, Math.PI * 2);
+  ctx.fillStyle = color;
+  ctx.fill();
+  ctx.lineWidth = lineWidth;
+  ctx.strokeStyle = stroke;
+  ctx.stroke();
+}
+
+function normalizeImageToCanvas(image) {
+  if (!image) {
+    throw new Error('No image provided');
+  }
+
+  const isImageData = image && typeof image.width === 'number' && typeof image.height === 'number' && image.data;
+  let width = 0;
+  let height = 0;
+
+  if (isImageData) {
+    width = image.width;
+    height = image.height;
+  } else {
+    width = image.width || image.naturalWidth;
+    height = image.height || image.naturalHeight;
+  }
+
+  if (!width || !height) {
+    throw new Error('Image must be loaded before creating the corner editor');
+  }
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d', { willReadFrequently: true });
+  if (!ctx) {
+    throw new Error('Failed to create 2D canvas context for source image');
+  }
+
+  if (isImageData) {
+    ctx.putImageData(image, 0, 0);
+  } else {
+    ctx.drawImage(image, 0, 0, width, height);
+  }
+
+  return { canvas, width, height };
+}
+
+export function createCornerEditor(options = {}) {
+  const container = options.container;
+  if (!container || typeof container.appendChild !== 'function') {
+    throw new Error('createCornerEditor requires a valid container element');
+  }
+
+  const { canvas: sourceCanvas, width: imageWidth, height: imageHeight } = normalizeImageToCanvas(options.image);
+
+  const editorCanvas = document.createElement('canvas');
+  // The canvas is positioned ABSOLUTELY and taken out of layout flow on
+  // purpose. If it participated in flow, its rendered size would feed back
+  // into the container size, the ResizeObserver would fire, we'd resize again,
+  // and the page would grow without bound (a runaway scrollbar that makes the
+  // handles impossible to grab). Out of flow, the canvas can never drive the
+  // container's size, so no feedback loop is possible regardless of borders,
+  // padding, or devicePixelRatio. We always set explicit pixel dimensions in
+  // updateCanvasSize().
+  editorCanvas.style.position = 'absolute';
+  editorCanvas.style.top = '0';
+  editorCanvas.style.left = '0';
+  editorCanvas.style.display = 'block';
+  editorCanvas.style.boxSizing = 'border-box';
+  editorCanvas.style.touchAction = 'none';
+  editorCanvas.style.userSelect = 'none';
+  editorCanvas.style.webkitUserSelect = 'none';
+  editorCanvas.style.cursor = 'crosshair';
+  editorCanvas.style.outline = 'none';
+
+  const keyboardEnabled = options.keyboard !== false;
+  if (keyboardEnabled) {
+    // Make the canvas focusable so it can receive keyboard input.
+    editorCanvas.tabIndex = 0;
+    editorCanvas.setAttribute('role', 'application');
+    editorCanvas.setAttribute('aria-label', 'Document corner editor. Use arrow keys to adjust the selected corner.');
+  }
+
+  // Track inline styles we mutate so destroy() can restore the host cleanly.
+  const restoreContainerStyle = {
+    position: container.style.position,
+    minHeight: container.style.minHeight
+  };
+  let changedContainerPosition = false;
+  let changedContainerMinHeight = false;
+
+  if (getComputedStyle(container).position === 'static') {
+    container.style.position = 'relative';
+    changedContainerPosition = true;
+  }
+
+  container.appendChild(editorCanvas);
+  const ctx = editorCanvas.getContext('2d');
+  if (!ctx) {
+    throw new Error('Failed to create 2D canvas context for corner editor');
+  }
+
+  const magnifier = {
+    enabled: options.magnifier?.enabled !== false,
+    size: options.magnifier?.size || 110,
+    zoom: options.magnifier?.zoom || 2,
+    margin: options.magnifier?.margin || 16,
+    borderColor: options.magnifier?.borderColor || '#ffffff',
+    borderWidth: options.magnifier?.borderWidth || 2,
+    crosshairColor: options.magnifier?.crosshairColor || '#ffffff',
+    crosshairSize: options.magnifier?.crosshairSize || 18
+  };
+
+  const nudges = {
+    enabled: !!options.nudges?.enabled,
+    steps: (options.nudges?.steps && options.nudges.steps.length ? options.nudges.steps : [1, 5]).map((v) => Math.max(1, Math.round(v)))
+  };
+
+  const defaultCorners = createDefaultCorners(imageWidth, imageHeight);
+  const requestedCorners = options.corners ? cloneCorners(options.corners) : defaultCorners;
+  let corners = cornersAreFiniteAndDistinct(requestedCorners) && isConvexQuadrilateral(requestedCorners)
+    ? requestedCorners
+    : defaultCorners;
+  const initialCorners = cloneCorners(corners);
+
+  let isDestroyed = false;
+  let activeCornerKey = null;
+  let dragPointerId = null;
+  let lastPointerPosition = null;
+
+  const handleHitArea = Math.max(24, options.handleHitArea || 48);
+  const handleRadius = Math.max(8, Math.min(16, handleHitArea * 0.3));
+  const cornerOrder = ['topLeft', 'topRight', 'bottomRight', 'bottomLeft'];
+  let view = { scale: 1, offsetX: 0, offsetY: 0, width: 1, height: 1 };
+
+  let nudgeControls = null;
+  let activeNudgeCorner = 'topLeft';
+  const runtimeGlobal = typeof window !== 'undefined' ? window : globalThis;
+
+  function emitChange() {
+    if (typeof options.onChange === 'function') {
+      options.onChange(cloneCorners(corners));
+    }
+  }
+
+  let lastDisplayWidth = 0;
+  let lastDisplayHeight = 0;
+
+  function computeDisplaySize() {
+    // Use the CONTENT box (clientWidth/clientHeight), never getBoundingClientRect
+    // — the latter includes the border, and sizing the canvas to a border-box
+    // value reintroduces the growth loop one border-width at a time.
+    const width = Math.max(1, Math.round(container.clientWidth));
+    let height = Math.round(container.clientHeight);
+
+    // When the container has no usable height of its own (auto-height
+    // layouts), derive one from the image aspect ratio so the editor is still
+    // usable, and give the container that height so the absolutely-positioned
+    // canvas is actually visible. Deterministic for a given width → no loop.
+    if (height < 80) {
+      const aspect = imageHeight / Math.max(1, imageWidth);
+      const viewportCap = (runtimeGlobal.innerHeight || 800) * 0.7;
+      height = Math.max(240, Math.round(Math.min(width * aspect, viewportCap)));
+      container.style.minHeight = height + 'px';
+      changedContainerMinHeight = true;
+    }
+
+    return { width, height: Math.max(1, height) };
+  }
+
+  function updateCanvasSize() {
+    const { width, height } = computeDisplaySize();
+    const dpr = runtimeGlobal.devicePixelRatio || 1;
+
+    lastDisplayWidth = width;
+    lastDisplayHeight = height;
+
+    // Decouple CSS size from the pixel buffer so the buffer height never feeds
+    // back into layout (see note where editorCanvas is created).
+    editorCanvas.style.width = width + 'px';
+    editorCanvas.style.height = height + 'px';
+
+    const bufferWidth = Math.round(width * dpr);
+    const bufferHeight = Math.round(height * dpr);
+    if (editorCanvas.width !== bufferWidth) editorCanvas.width = bufferWidth;
+    if (editorCanvas.height !== bufferHeight) editorCanvas.height = bufferHeight;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+    const padding = 12;
+    const availableWidth = Math.max(1, width - padding * 2);
+    const availableHeight = Math.max(1, height - padding * 2);
+    const scale = Math.min(availableWidth / imageWidth, availableHeight / imageHeight);
+    const drawWidth = imageWidth * scale;
+    const drawHeight = imageHeight * scale;
+
+    view = {
+      scale,
+      offsetX: Math.round((width - drawWidth) / 2),
+      offsetY: Math.round((height - drawHeight) / 2),
+      width,
+      height
+    };
+  }
+
+  function imageToView(point) {
+    return {
+      x: view.offsetX + point.x * view.scale,
+      y: view.offsetY + point.y * view.scale
+    };
+  }
+
+  function viewToImage(x, y) {
+    const px = (x - view.offsetX) / view.scale;
+    const py = (y - view.offsetY) / view.scale;
+    return {
+      x: Math.max(0, Math.min(imageWidth, px)),
+      y: Math.max(0, Math.min(imageHeight, py))
+    };
+  }
+
+  function cornersValid(nextCorners) {
+    return cornersAreFiniteAndDistinct(nextCorners) && isConvexQuadrilateral(nextCorners);
+  }
+
+  function getEventCanvasPoint(event) {
+    const rect = editorCanvas.getBoundingClientRect();
+    return {
+      x: event.clientX - rect.left,
+      y: event.clientY - rect.top
+    };
+  }
+
+  function hitTestCorner(canvasX, canvasY) {
+    let hit = null;
+    let bestDistance = Infinity;
+
+    for (const key of cornerOrder) {
+      const p = imageToView(corners[key]);
+      const d = Math.hypot(canvasX - p.x, canvasY - p.y);
+      if (d <= handleHitArea && d < bestDistance) {
+        bestDistance = d;
+        hit = key;
+      }
+    }
+
+    return hit;
+  }
+
+  function drawPolygonOverlay() {
+    const points = cornerOrder.map((key) => imageToView(corners[key]));
+
+    ctx.save();
+    ctx.fillStyle = 'rgba(15, 23, 42, 0.40)';
+    ctx.beginPath();
+    ctx.rect(0, 0, view.width, view.height);
+    ctx.moveTo(points[0].x, points[0].y);
+    for (let i = 1; i < points.length; i++) {
+      ctx.lineTo(points[i].x, points[i].y);
+    }
+    ctx.closePath();
+    ctx.fill('evenodd');
+    ctx.restore();
+
+    ctx.save();
+    ctx.strokeStyle = '#22c55e';
+    ctx.lineWidth = 3;
+    ctx.beginPath();
+    ctx.moveTo(points[0].x, points[0].y);
+    for (let i = 1; i < points.length; i++) {
+      ctx.lineTo(points[i].x, points[i].y);
+    }
+    ctx.closePath();
+    ctx.stroke();
+    ctx.restore();
+
+    for (const key of cornerOrder) {
+      const p = imageToView(corners[key]);
+      const isActive = key === activeCornerKey;
+      drawHandle(
+        ctx,
+        p,
+        isActive ? handleRadius + 1 : handleRadius,
+        isActive ? '#f59e0b' : '#ffffff',
+        isActive ? '#7c2d12' : '#0f172a',
+        2
+      );
+    }
+  }
+
+  function drawMagnifier() {
+    if (!magnifier.enabled || !activeCornerKey || !lastPointerPosition) {
+      return;
+    }
+
+    const active = corners[activeCornerKey];
+    const size = magnifier.size;
+    const radius = size / 2;
+    const zoom = Math.max(1.1, magnifier.zoom);
+
+    let lensX = lastPointerPosition.x + radius + magnifier.margin;
+    let lensY = lastPointerPosition.y - radius - magnifier.margin;
+
+    if (lensX + radius > view.width) {
+      lensX = lastPointerPosition.x - radius - magnifier.margin;
+    }
+    if (lensY - radius < 0) {
+      lensY = lastPointerPosition.y + radius + magnifier.margin;
+    }
+
+    lensX = Math.max(radius + 2, Math.min(view.width - radius - 2, lensX));
+    lensY = Math.max(radius + 2, Math.min(view.height - radius - 2, lensY));
+
+    const sampleSize = size / zoom;
+    const sx = Math.max(0, Math.min(imageWidth - sampleSize, active.x - sampleSize / 2));
+    const sy = Math.max(0, Math.min(imageHeight - sampleSize, active.y - sampleSize / 2));
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(lensX, lensY, radius, 0, Math.PI * 2);
+    ctx.clip();
+    ctx.drawImage(sourceCanvas, sx, sy, sampleSize, sampleSize, lensX - radius, lensY - radius, size, size);
+    ctx.restore();
+
+    ctx.save();
+    ctx.beginPath();
+    ctx.arc(lensX, lensY, radius, 0, Math.PI * 2);
+    ctx.lineWidth = magnifier.borderWidth;
+    ctx.strokeStyle = magnifier.borderColor;
+    ctx.stroke();
+
+    const ch = magnifier.crosshairSize / 2;
+    ctx.strokeStyle = magnifier.crosshairColor;
+    ctx.lineWidth = 1.5;
+    ctx.beginPath();
+    ctx.moveTo(lensX - ch, lensY);
+    ctx.lineTo(lensX + ch, lensY);
+    ctx.moveTo(lensX, lensY - ch);
+    ctx.lineTo(lensX, lensY + ch);
+    ctx.stroke();
+    ctx.restore();
+  }
+
+  function render() {
+    if (isDestroyed) return;
+
+    ctx.clearRect(0, 0, view.width, view.height);
+    ctx.drawImage(
+      sourceCanvas,
+      0,
+      0,
+      imageWidth,
+      imageHeight,
+      view.offsetX,
+      view.offsetY,
+      imageWidth * view.scale,
+      imageHeight * view.scale
+    );
+    drawPolygonOverlay();
+    drawMagnifier();
+  }
+
+  // Coalesce paints to one per animation frame. Pointer/keyboard updates mutate
+  // corner state synchronously but only request a frame, so a fast drag over a
+  // large image never triggers more than one full repaint per frame.
+  const raf = typeof runtimeGlobal.requestAnimationFrame === 'function'
+    ? runtimeGlobal.requestAnimationFrame.bind(runtimeGlobal)
+    : null;
+  const caf = typeof runtimeGlobal.cancelAnimationFrame === 'function'
+    ? runtimeGlobal.cancelAnimationFrame.bind(runtimeGlobal)
+    : null;
+  let rafId = null;
+
+  function scheduleRender() {
+    if (isDestroyed) return;
+    if (!raf) {
+      render();
+      return;
+    }
+    if (rafId !== null) return;
+    rafId = raf(() => {
+      rafId = null;
+      render();
+    });
+  }
+
+  function setCorner(nextCornerKey, nextPoint) {
+    const candidate = cloneCorners(corners);
+    candidate[nextCornerKey] = {
+      x: Math.max(0, Math.min(imageWidth, nextPoint.x)),
+      y: Math.max(0, Math.min(imageHeight, nextPoint.y))
+    };
+
+    if (!cornersValid(candidate)) {
+      return false;
+    }
+
+    corners = candidate;
+    activeNudgeCorner = nextCornerKey;
+    emitChange();
+    scheduleRender();
+    return true;
+  }
+
+  function buildNudgeControls() {
+    if (!nudges.enabled) {
+      return;
+    }
+
+    nudgeControls = document.createElement('div');
+    nudgeControls.style.position = 'absolute';
+    nudgeControls.style.right = '8px';
+    nudgeControls.style.bottom = '8px';
+    nudgeControls.style.background = 'rgba(15, 23, 42, 0.9)';
+    nudgeControls.style.border = '1px solid rgba(148, 163, 184, 0.5)';
+    nudgeControls.style.borderRadius = '10px';
+    nudgeControls.style.padding = '8px';
+    nudgeControls.style.display = 'grid';
+    nudgeControls.style.gridTemplateColumns = 'repeat(4, auto)';
+    nudgeControls.style.gap = '6px';
+    nudgeControls.style.zIndex = '2';
+
+    const makeButton = (glyph, ariaLabel, dx, dy, step) => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.textContent = glyph + (step > 1 ? ' ' + step : '');
+      btn.setAttribute('aria-label', ariaLabel);
+      btn.style.border = '1px solid #475569';
+      btn.style.background = '#0f172a';
+      btn.style.color = '#e2e8f0';
+      btn.style.borderRadius = '6px';
+      btn.style.padding = '4px 8px';
+      btn.style.fontSize = '13px';
+      btn.style.lineHeight = '1';
+      btn.style.cursor = 'pointer';
+      btn.addEventListener('click', () => {
+        const current = corners[activeNudgeCorner];
+        setCorner(activeNudgeCorner, {
+          x: current.x + dx * step,
+          y: current.y + dy * step
+        });
+      });
+      return btn;
+    };
+
+    for (const step of nudges.steps) {
+      nudgeControls.appendChild(makeButton('←', `Move left ${step}px`, -1, 0, step));
+      nudgeControls.appendChild(makeButton('→', `Move right ${step}px`, 1, 0, step));
+      nudgeControls.appendChild(makeButton('↑', `Move up ${step}px`, 0, -1, step));
+      nudgeControls.appendChild(makeButton('↓', `Move down ${step}px`, 0, 1, step));
+    }
+
+    container.appendChild(nudgeControls);
+  }
+
+  function handlePointerDown(event) {
+    if (isDestroyed) return;
+    const point = getEventCanvasPoint(event);
+    const hitCorner = hitTestCorner(point.x, point.y);
+    if (!hitCorner) return;
+
+    if (typeof event.preventDefault === 'function') {
+      event.preventDefault();
+    }
+
+    activeCornerKey = hitCorner;
+    activeNudgeCorner = hitCorner;
+    dragPointerId = event.pointerId;
+    lastPointerPosition = point;
+    editorCanvas.style.cursor = 'grabbing';
+
+    // Focus so keyboard nudging works on the corner the user just grabbed.
+    if (keyboardEnabled && typeof editorCanvas.focus === 'function') {
+      try { editorCanvas.focus({ preventScroll: true }); } catch (_) { editorCanvas.focus(); }
+    }
+
+    if (editorCanvas.setPointerCapture && dragPointerId !== undefined) {
+      editorCanvas.setPointerCapture(dragPointerId);
+    }
+
+    scheduleRender();
+  }
+
+  function handlePointerMove(event) {
+    if (isDestroyed) return;
+
+    const point = getEventCanvasPoint(event);
+
+    if (!activeCornerKey) {
+      // Hover feedback so it's obvious the handles are grabbable.
+      editorCanvas.style.cursor = hitTestCorner(point.x, point.y) ? 'grab' : 'crosshair';
+      return;
+    }
+    if (dragPointerId !== null && event.pointerId !== dragPointerId) return;
+
+    lastPointerPosition = point;
+    const imagePoint = viewToImage(point.x, point.y);
+    setCorner(activeCornerKey, imagePoint);
+  }
+
+  function handlePointerUp(event) {
+    if (!activeCornerKey) return;
+    if (dragPointerId !== null && event.pointerId !== dragPointerId) return;
+    if (editorCanvas.releasePointerCapture && dragPointerId !== null && dragPointerId !== undefined) {
+      try { editorCanvas.releasePointerCapture(dragPointerId); } catch (_) { /* ignore */ }
+    }
+    activeCornerKey = null;
+    dragPointerId = null;
+    lastPointerPosition = null;
+    editorCanvas.style.cursor = 'crosshair';
+    scheduleRender();
+  }
+
+  function handleKeyDown(event) {
+    if (isDestroyed || !keyboardEnabled) return;
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      confirmEditor();
+      return;
+    }
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      cancelEditor();
+      return;
+    }
+
+    let dx = 0;
+    let dy = 0;
+    if (event.key === 'ArrowLeft') dx = -1;
+    else if (event.key === 'ArrowRight') dx = 1;
+    else if (event.key === 'ArrowUp') dy = -1;
+    else if (event.key === 'ArrowDown') dy = 1;
+    else return;
+
+    event.preventDefault();
+    // Shift = coarse step (largest configured nudge step), otherwise 1px.
+    const step = event.shiftKey ? nudges.steps[nudges.steps.length - 1] || 10 : 1;
+    const current = corners[activeNudgeCorner];
+    setCorner(activeNudgeCorner, {
+      x: current.x + dx * step,
+      y: current.y + dy * step
+    });
+  }
+
+  function handleMouseDown(event) {
+    handlePointerDown({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      pointerId: 1
+    });
+  }
+
+  function handleMouseMove(event) {
+    handlePointerMove({
+      clientX: event.clientX,
+      clientY: event.clientY,
+      pointerId: 1
+    });
+  }
+
+  function handleTouchStart(event) {
+    const touch = event.touches[0];
+    if (!touch) return;
+    const point = getEventCanvasPoint(touch);
+    // Only swallow the gesture (and block page scroll) when actually grabbing
+    // a handle, so taps elsewhere stay responsive on legacy touch browsers.
+    if (hitTestCorner(point.x, point.y)) {
+      event.preventDefault();
+    }
+    handlePointerDown({
+      clientX: touch.clientX,
+      clientY: touch.clientY,
+      pointerId: 2
+    });
+  }
+
+  function handleTouchMove(event) {
+    const touch = event.touches[0];
+    if (!touch) return;
+    event.preventDefault();
+    handlePointerMove({
+      clientX: touch.clientX,
+      clientY: touch.clientY,
+      pointerId: 2
+    });
+  }
+
+  function attachEvents() {
+    if (typeof runtimeGlobal.PointerEvent !== 'undefined') {
+      editorCanvas.addEventListener('pointerdown', handlePointerDown);
+      editorCanvas.addEventListener('pointermove', handlePointerMove);
+      editorCanvas.addEventListener('pointerup', handlePointerUp);
+      editorCanvas.addEventListener('pointercancel', handlePointerUp);
+    } else {
+      editorCanvas.addEventListener('mousedown', handleMouseDown);
+      if (typeof runtimeGlobal.addEventListener === 'function') {
+        runtimeGlobal.addEventListener('mousemove', handleMouseMove);
+        runtimeGlobal.addEventListener('mouseup', handlePointerUp);
+      }
+      editorCanvas.addEventListener('touchstart', handleTouchStart, { passive: false });
+      editorCanvas.addEventListener('touchmove', handleTouchMove, { passive: false });
+      editorCanvas.addEventListener('touchend', handlePointerUp);
+      editorCanvas.addEventListener('touchcancel', handlePointerUp);
+    }
+    if (keyboardEnabled) {
+      editorCanvas.addEventListener('keydown', handleKeyDown);
+    }
+  }
+
+  function detachEvents() {
+    editorCanvas.removeEventListener('pointerdown', handlePointerDown);
+    editorCanvas.removeEventListener('pointermove', handlePointerMove);
+    editorCanvas.removeEventListener('pointerup', handlePointerUp);
+    editorCanvas.removeEventListener('pointercancel', handlePointerUp);
+    editorCanvas.removeEventListener('mousedown', handleMouseDown);
+    if (typeof runtimeGlobal.removeEventListener === 'function') {
+      runtimeGlobal.removeEventListener('mousemove', handleMouseMove);
+      runtimeGlobal.removeEventListener('mouseup', handlePointerUp);
+    }
+    editorCanvas.removeEventListener('touchstart', handleTouchStart);
+    editorCanvas.removeEventListener('touchmove', handleTouchMove);
+    editorCanvas.removeEventListener('touchend', handlePointerUp);
+    editorCanvas.removeEventListener('touchcancel', handlePointerUp);
+    editorCanvas.removeEventListener('keydown', handleKeyDown);
+  }
+
+  // Keep the canvas crisp when the page moves between displays with different
+  // pixel densities (e.g. dragging the window to an external monitor) or on
+  // browser zoom. matchMedia for the current ratio fires once when it changes.
+  let dprCleanup = null;
+  function watchDevicePixelRatio() {
+    if (typeof runtimeGlobal.matchMedia !== 'function') return;
+    if (dprCleanup) dprCleanup();
+    const dpr = runtimeGlobal.devicePixelRatio || 1;
+    const mq = runtimeGlobal.matchMedia(`(resolution: ${dpr}dppx)`);
+    const onChange = () => {
+      if (isDestroyed) return;
+      updateCanvasSize();
+      scheduleRender();
+      watchDevicePixelRatio();
+    };
+    if (typeof mq.addEventListener === 'function') {
+      mq.addEventListener('change', onChange);
+      dprCleanup = () => mq.removeEventListener('change', onChange);
+    } else if (typeof mq.addListener === 'function') {
+      mq.addListener(onChange);
+      dprCleanup = () => mq.removeListener(onChange);
+    } else {
+      dprCleanup = null;
+    }
+  }
+
+  function confirmEditor() {
+    const output = cloneCorners(corners);
+    if (typeof options.onConfirm === 'function') {
+      options.onConfirm(output);
+    }
+    return output;
+  }
+
+  function cancelEditor() {
+    if (typeof options.onCancel === 'function') {
+      options.onCancel();
+    }
+  }
+
+  const resizeObserver = typeof ResizeObserver !== 'undefined'
+    ? new ResizeObserver(() => {
+        if (isDestroyed) return;
+        const next = computeDisplaySize();
+        // Ignore observations that don't actually change our display size.
+        // This is a safety net against any layout feedback loop.
+        if (next.width === lastDisplayWidth && next.height === lastDisplayHeight) {
+          return;
+        }
+        updateCanvasSize();
+        scheduleRender();
+      })
+    : null;
+
+  updateCanvasSize();
+  buildNudgeControls();
+  attachEvents();
+  watchDevicePixelRatio();
+  if (resizeObserver) {
+    resizeObserver.observe(container);
+  }
+  render();
+
+  return {
+    getCorners() {
+      return cloneCorners(corners);
+    },
+
+    setCorners(nextCorners) {
+      if (!nextCorners || !cornersValid(nextCorners)) {
+        return false;
+      }
+      corners = cloneCorners(nextCorners);
+      emitChange();
+      scheduleRender();
+      return true;
+    },
+
+    reset() {
+      corners = cloneCorners(initialCorners);
+      emitChange();
+      scheduleRender();
+    },
+
+    nudge(cornerKey, dx, dy, step = 1) {
+      if (!cornerOrder.includes(cornerKey)) {
+        return false;
+      }
+      return setCorner(cornerKey, {
+        x: corners[cornerKey].x + dx * step,
+        y: corners[cornerKey].y + dy * step
+      });
+    },
+
+    confirm() {
+      return confirmEditor();
+    },
+
+    cancel() {
+      cancelEditor();
+    },
+
+    destroy() {
+      if (isDestroyed) return;
+      isDestroyed = true;
+      if (rafId !== null && caf) {
+        caf(rafId);
+        rafId = null;
+      }
+      if (dprCleanup) {
+        dprCleanup();
+        dprCleanup = null;
+      }
+      if (resizeObserver) {
+        resizeObserver.disconnect();
+      }
+      detachEvents();
+      if (nudgeControls && nudgeControls.parentNode) {
+        nudgeControls.parentNode.removeChild(nudgeControls);
+      }
+      if (editorCanvas.parentNode) {
+        editorCanvas.parentNode.removeChild(editorCanvas);
+      }
+      // Restore any inline styles we set on the host so it can be reused cleanly.
+      if (changedContainerPosition) {
+        container.style.position = restoreContainerStyle.position;
+      }
+      if (changedContainerMinHeight) {
+        container.style.minHeight = restoreContainerStyle.minHeight;
+      }
+    }
+  };
+}

--- a/src/edgeDetection.js
+++ b/src/edgeDetection.js
@@ -27,8 +27,14 @@ async function initializeWasmInternal() {
   // file:// URLs in Node. Load bytes directly when running in Node.
   if (isNodeRuntime()) {
     try {
-      const { readFile } = await import('node:fs/promises');
-      const { fileURLToPath } = await import('node:url');
+      // Specifiers are built at runtime + flagged @vite-ignore so neither our
+      // bundler nor a downstream browser bundler tries to statically resolve
+      // (or warn about) these Node-only builtins. This branch never runs in a
+      // browser because isNodeRuntime() is false there.
+      const fsModule = 'node:fs/promises';
+      const urlModule = 'node:url';
+      const { readFile } = await import(/* @vite-ignore */ fsModule);
+      const { fileURLToPath } = await import(/* @vite-ignore */ urlModule);
       const moduleUrl = new URL(import.meta.url);
       moduleUrl.search = '';
       moduleUrl.hash = '';

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@
 import { detectDocumentContour, approximatePolygon } from './contourDetection.js';
 import { findCornerPoints } from './cornerDetection.js';
 import { cannyEdgeDetector, initializeWasm } from './edgeDetection.js';
+export { createCornerEditor } from './cornerEditor.js';
 
 /**
  * Global initialization helper for convenience.

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -2,9 +2,13 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect } from 'vitest';
-import { scanDocument, Scanner } from './index.js';
+import { scanDocument, Scanner, createCornerEditor } from './index.js';
 import { createCanvas, loadImage } from 'canvas';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 // Shim ImageData if it's not defined (JSDOM doesn't have it by default)
 if (typeof ImageData === 'undefined') {
@@ -19,12 +23,44 @@ if (typeof ImageData === 'undefined') {
 
 if (typeof globalThis.document === 'undefined') {
   globalThis.document = {
+    body: {
+      appendChild() {},
+      removeChild() {}
+    },
     createElement(tagName) {
-      if (tagName !== 'canvas') {
-        throw new Error(`Unsupported element requested in tests: ${tagName}`);
+      if (tagName === 'canvas') {
+        const c = createCanvas(1, 1);
+        c.style = {};
+        c.addEventListener = () => {};
+        c.removeEventListener = () => {};
+        c.setPointerCapture = () => {};
+        c.getBoundingClientRect = () => ({ width: 640, height: 480, left: 0, top: 0 });
+        return c;
       }
-      return createCanvas(1, 1);
+
+      return {
+        style: {},
+        appendChild() {},
+        removeChild() {},
+        remove() {},
+        addEventListener() {},
+        removeEventListener() {},
+        getBoundingClientRect() {
+          return { width: 640, height: 480, left: 0, top: 0 };
+        }
+      };
     }
+  };
+}
+
+if (typeof globalThis.getComputedStyle === 'undefined') {
+  globalThis.getComputedStyle = () => ({ position: 'static' });
+}
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  globalThis.ResizeObserver = class {
+    observe() {}
+    disconnect() {}
   };
 }
 
@@ -39,12 +75,71 @@ describe('Scanner API', () => {
     expect(scanner.initialize).toBeDefined();
   });
 
+  it('should expose createCornerEditor function', () => {
+    expect(createCornerEditor).toBeDefined();
+  });
+
   it('should handle missing image gracefully', async () => {
     try {
       await scanDocument(null);
     } catch (e) {
       expect(e.message).toBe('No image provided');
     }
+  });
+});
+
+describe('Corner Editor API', () => {
+  it('should create and confirm manual corner updates', async () => {
+    const host = document.createElement('div');
+    host.style.width = '640px';
+    host.style.height = '480px';
+    document.body.appendChild(host);
+
+    const imgPath = path.join(__dirname, '..', 'testImages', 'test-sized.png');
+    const img = await loadImage(imgPath);
+
+    let confirmed = null;
+    const editor = createCornerEditor({
+      container: host,
+      image: img,
+      nudges: { enabled: true, steps: [1] },
+      onConfirm(corners) {
+        confirmed = corners;
+      }
+    });
+
+    const before = editor.getCorners();
+    const nudged = editor.nudge('topLeft', 1, 0, 1);
+    expect(nudged).toBe(true);
+
+    const after = editor.confirm();
+    expect(after.topLeft.x).toBeGreaterThan(before.topLeft.x);
+    expect(confirmed).toBeTruthy();
+
+    editor.destroy();
+    host.remove();
+  });
+
+  it('should reject invalid corner sets', async () => {
+    const host = document.createElement('div');
+    host.style.width = '640px';
+    host.style.height = '480px';
+    document.body.appendChild(host);
+
+    const imgPath = path.join(__dirname, '..', 'testImages', 'test-sized.png');
+    const img = await loadImage(imgPath);
+    const editor = createCornerEditor({ container: host, image: img });
+
+    const invalid = {
+      topLeft: { x: 100, y: 100 },
+      topRight: { x: 100, y: 100 },
+      bottomRight: { x: 110, y: 110 },
+      bottomLeft: { x: 120, y: 120 }
+    };
+
+    expect(editor.setCorners(invalid)).toBe(false);
+    editor.destroy();
+    host.remove();
   });
 });
 

--- a/src/scanic.d.ts
+++ b/src/scanic.d.ts
@@ -10,6 +10,57 @@ export interface CornerPoints {
   bottomLeft: Point;
 }
 
+export interface CornerEditorMagnifierOptions {
+  enabled?: boolean;
+  size?: number;
+  zoom?: number;
+  margin?: number;
+  borderColor?: string;
+  borderWidth?: number;
+  crosshairColor?: string;
+  crosshairSize?: number;
+}
+
+export interface CornerEditorNudgesOptions {
+  enabled?: boolean;
+  steps?: number[];
+}
+
+export interface CornerEditorOptions {
+  /** Host element the editor canvas is mounted into. */
+  container: HTMLElement;
+  /** Source image to adjust corners against. */
+  image: HTMLImageElement | HTMLCanvasElement | ImageData;
+  /** Initial corner positions (image-space pixels). Defaults to an inset quad. */
+  corners?: CornerPoints;
+  magnifier?: CornerEditorMagnifierOptions;
+  nudges?: CornerEditorNudgesOptions;
+  /** Touch/click target radius (px) around each handle. Default 48. */
+  handleHitArea?: number;
+  /**
+   * Enable keyboard control of the focused canvas (default true):
+   * arrow keys nudge the active corner (Shift = coarse step),
+   * Enter confirms, Escape cancels.
+   */
+  keyboard?: boolean;
+  /** Fired on every corner change (drag, nudge, keyboard). */
+  onChange?: (corners: CornerPoints) => void;
+  /** Fired by confirm()/Enter with the final corners. */
+  onConfirm?: (corners: CornerPoints) => void;
+  /** Fired by cancel()/Escape. */
+  onCancel?: () => void;
+}
+
+export interface CornerEditor {
+  getCorners(): CornerPoints;
+  setCorners(corners: CornerPoints): boolean;
+  reset(): void;
+  nudge(cornerKey: keyof CornerPoints, dx: number, dy: number, step?: number): boolean;
+  confirm(): CornerPoints;
+  cancel(): void;
+  destroy(): void;
+}
+
 export interface DetectionOptions {
   mode?: 'detect' | 'extract';
   output?: 'canvas' | 'imagedata' | 'dataurl';
@@ -82,3 +133,8 @@ export class Scanner {
     options?: DetectionOptions
   ): Promise<ScannerResult>;
 }
+
+/**
+ * Create a manual corner adjustment editor.
+ */
+export function createCornerEditor(options: CornerEditorOptions): CornerEditor;


### PR DESCRIPTION
﻿## Summary

Adds an interactive **manual corner editor** so users can fine-tune detected document corners before extraction, plus a set of robustness, accessibility, and packaging improvements.

### Feature: `createCornerEditor`
- Dependency-free editor: drag corner handles over the source image, with a magnifier, nudge buttons, and full keyboard control.
- Demo integration (auto-opens on low-confidence detections, plus a manual "Adjust Corners" button), tests, type defs, and README docs.

### Robustness & UX fixes
- **Fixed a runaway-scroll bug:** the editor canvas is now positioned out of layout flow and sized from the container content box, eliminating a `ResizeObserver`/HiDPI feedback loop that grew the page unboundedly and made handles impossible to grab.
- Repaints coalesced to one per animation frame for smooth dragging on large images.
- Keyboard a11y: arrow keys nudge the active corner (Shift = coarse step), Enter confirms, Escape cancels; focusable canvas with ARIA labels.
- `destroy()` restores mutated host inline styles and tears down rAF / DPR watcher / pointer capture.
- Crisp re-render on `devicePixelRatio` changes (monitor move / browser zoom).
- Page scroll prevented while grabbing a handle on touch.

### Packaging / build
- Hardened the Node-only `node:fs/promises` / `node:url` dynamic imports (runtime specifier + `@vite-ignore`): removes the "externalized for browser compatibility" warning that leaked to consumers, and restores the Node wasm disk-read fast-path that was being stubbed out in the published bundle. Still guarded by `isNodeRuntime()`, so browsers never reach it.
- Added `"sideEffects": false` to enable tree-shaking for consumers who only import `scanDocument`.

## Testing
- `npm test` -> 26/26 passing
- `npm run build` -> clean (no externalization warning); `createCornerEditor` present in both ESM and UMD bundles.

## Notes
- Targets a minor version bump (`1.0.8` -> `1.1.0`): additive, backward-compatible.
- `dist/` is gitignored and built in CI, so no build artifacts are included here.
