### PR TITLE
ci: bump checkout/setup-node to v5 (Node 24 runtime)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
@@ -54,10 +54,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
         

--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -24,10 +24,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
         cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v5
       with:
         node-version: '20'
         registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
﻿## Summary
Bumps `actions/checkout@v4` -> `@v5` and `actions/setup-node@v4` -> `@v5` across all three workflows (CI, release, deploy-demo).

## Why
GitHub is deprecating the Node 20 actions runtime: actions still on Node 20 are **forced to Node 24 on 2026-06-16**, and Node 20 is **removed from runners on 2026-09-16**. The `@v5` releases of both actions run on Node 24, which clears the deprecation warning seen in the v1.1.0 release run.

## Scope
- No source/runtime changes — workflow YAML only.
- Third-party actions (peaceiris/actions-gh-pages, softprops/action-gh-release) are unaffected by this deprecation and left as-is.
