### PR TITLE
fix: prevent renderer crash on old Chromium (Electron 13) by gating WASM (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Electron 13 / old-Chromium renderer crash** ([#8](https://github.com/marquaye/scanic/issues/8)): instantiating the SIMD WebAssembly module hard-crashed the renderer on engines based on Chromium < 96 (e.g. Electron 13 / V8 9.1) — a native abort that a surrounding `try/catch` could not recover from. The WASM module is now feature-gated behind a non-crashing `WebAssembly.validate()` probe, and incompatible engines transparently use the existing pure-JS implementation instead. `initialize()` and `Scanner.initialize()` no longer reject when WASM is unavailable, since it is an optional accelerator.
+
 ## [1.0.7] - 2026-05-14
 
 ### Added

--- a/src/edgeDetection.js
+++ b/src/edgeDetection.js
@@ -17,12 +17,60 @@ import init, {
 // Initialize the wasm module
 let wasmReadyPromise = null;
 let hasLoggedFullCannyFallback = false;
+let wasmSupportCache = null;
 
 function isNodeRuntime() {
   return typeof process !== 'undefined' && !!process.versions?.node;
 }
 
+/**
+ * Statically checks whether the current engine is new enough to run scanic's
+ * compiled WASM without crashing.
+ *
+ * Older engines (notably Electron 13 / Chromium 91 — V8 9.1) *hard-crash the
+ * process* while compiling this wasm-bindgen + SIMD128 module, instead of
+ * throwing a catchable error. The abort happens during instantiation, so a
+ * surrounding try/catch cannot recover from it; the only safe option is to never
+ * start it on such engines and use the pure-JS path instead.
+ *
+ * We use `WebAssembly.validate()` — a static check that never instantiates and
+ * never crashes — to probe two proposals:
+ *   - SIMD128: the module genuinely requires it.
+ *   - reference-types: the module does not strictly need this, but support for
+ *     it is a reliable proxy for "Chromium >= 96 / a modern V8". Every engine
+ *     old enough to crash on this module also lacks reference-types, so gating
+ *     on it cleanly excludes the crash-prone runtimes while keeping WASM enabled
+ *     everywhere it is safe.
+ * @returns {boolean}
+ */
+function wasmModuleSupported() {
+  if (wasmSupportCache !== null) return wasmSupportCache;
+
+  let supported = false;
+  if (typeof WebAssembly === 'object' && typeof WebAssembly.validate === 'function') {
+    // Canonical wasm-feature-detect probe modules.
+    const simd = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 123, 3, 2, 1, 0, 10, 10, 1, 8, 0, 65, 0, 253, 15, 253, 98, 11]);
+    const referenceTypes = new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 5, 1, 96, 0, 1, 111, 3, 2, 1, 0, 10, 6, 1, 4, 0, 208, 111, 11]);
+    try {
+      supported = WebAssembly.validate(simd) && WebAssembly.validate(referenceTypes);
+    } catch {
+      supported = false;
+    }
+  }
+
+  wasmSupportCache = supported;
+  return supported;
+}
+
 async function initializeWasmInternal() {
+  // Bail out before instantiation on engines that can't run this module. On
+  // some of them (e.g. Electron 13 / Chromium 91) a failed instantiation is a
+  // native renderer crash rather than a catchable exception, so the only safe
+  // option is to never start it — callers then use the pure-JS path.
+  if (!wasmModuleSupported()) {
+    throw new Error('scanic: WebAssembly features required by the WASM module (reference-types, SIMD) are unavailable in this engine; using the JavaScript fallback.');
+  }
+
   // wasm-bindgen's default init path uses fetch(URL), which can fail on
   // file:// URLs in Node. Load bytes directly when running in Node.
   if (isNodeRuntime()) {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,15 @@ export { createCornerEditor } from './cornerEditor.js';
  * Global initialization helper for convenience.
  */
 export async function initialize() {
-  return await initializeWasm();
+  // WASM is an optional accelerator: warming it up is best-effort. On engines
+  // that can't run the module (e.g. Electron 13 / Chromium 91) initialization
+  // rejects, but the scanner still works via its pure-JS fallbacks, so we
+  // resolve instead of surfacing a fatal error to the caller.
+  try {
+    return await initializeWasm();
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -36,7 +44,12 @@ export class Scanner {
    */
   async initialize() {
     if (this.initialized) return;
-    await initializeWasm();
+    // Best-effort WASM warm-up; pure-JS fallbacks cover engines without it.
+    try {
+      await initializeWasm();
+    } catch {
+      // WASM unavailable — continue with the JavaScript implementation.
+    }
     this.initialized = true;
   }
 


### PR DESCRIPTION
Fixes #8

## Problem

Running scanic in Electron 13.6.9 (Chromium 91 / V8 9.1) crashes the renderer process when `scanDocument` is called. The crash is a **native abort** (`exitCode 0x80000003`, V8 fatal), not a catchable JS exception — so the library's existing per-call `try/catch` → JS fallbacks never get a chance to run.

## Root cause

Reproduced in a minimal Electron 13.6.9 app (main-process `render-process-gone` capture):

- The crash happens **during WebAssembly module compilation/instantiation** (`initialize()` alone crashes; disabling WASM entirely works fine and returns correct corners).
- It is **not** reference-types: rebuilding the module with reference-types/multivalue stripped still crashed.
- A *trivial* SIMD module compiles & instantiates fine on Chromium 91, but scanic's full module does not — V8 9.1's compiler aborts on a specific SIMD instruction it doesn't implement. `WebAssembly.validate()` returns `false` for the module on these engines, but actually instantiating it is what aborts.

There is no way to make this WASM run on Chromium < 96 short of dropping SIMD (which would erase the performance benefit), so those engines must use the pure-JS path.

## Fix

Gate WASM instantiation behind a **non-crashing `WebAssembly.validate()` probe** before ever calling the wasm-bindgen `init()`:

- Probe SIMD128 (the module requires it) and reference-types. Reference-types support is a reliable proxy for "Chromium >= 96 / a modern V8" — every engine old enough to crash on this module also lacks it, so the probe cleanly excludes exactly the crash-prone runtimes while keeping WASM enabled everywhere it is safe.
- The result is memoized; incompatible engines transparently use the existing pure-JS implementation.
- `initialize()` / `Scanner.initialize()` now resolve instead of rejecting when WASM is unavailable (it's an optional accelerator), so `Scanner.scan()` keeps working.

## Verification

- **Electron 13.6.9**: `extract` (the reporter's exact call), `detect`, `Scanner.scan`, and `initialize()` all succeed — no crash.
- **Modern engines (Node 22 / Electron ≥16)**: WASM still instantiated and used; `26/26` tests pass.
- **Performance**: end-to-end is unchanged on modern engines (same WASM path + a one-time `validate()` of two ~30-byte probe modules). The JS fallback measured at parity with WASM for this workload, so gated engines lose nothing meaningful.

## Changes

- `src/edgeDetection.js` — `wasmModuleSupported()` gate before WASM init.
- `src/index.js` — graceful `initialize()` / `Scanner.initialize()`.
- `CHANGELOG.md` — Unreleased entry.