### PR TITLE
fix: make the lazy ML-detector import safe for webpack consumers

### DIFF
--- a/scripts/build-lib.mjs
+++ b/scripts/build-lib.mjs
@@ -29,7 +29,11 @@ import { fileURLToPath } from 'node:url';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 const entry = path.resolve(root, 'src/index.js');
-const terserOptions = { compress: { drop_console: true, drop_debugger: true } };
+const terserOptions = {
+  compress: { drop_console: true, drop_debugger: true },
+  // Keep the webpackIgnore magic comment on the lazy ML import (see src/index.js).
+  format: { comments: /webpackIgnore/ },
+};
 
 // Pass 1 - ES build with onnxruntime-web bundled into a lazy chunk.
 await build({

--- a/src/distBundle.test.js
+++ b/src/distBundle.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const distEntry = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', 'dist', 'scanic.js');
+
+// Only runs where dist exists (always true on the release path: prepublishOnly builds).
+describe.skipIf(!existsSync(distEntry))('dist/scanic.js', () => {
+  it('keeps the webpackIgnore comment on the lazy ML-chunk import', () => {
+    const code = readFileSync(distEntry, 'utf8');
+    // If the toolchain ever strips this comment, webpack consumers break — fail the release.
+    expect(code).toMatch(
+      /import\(\s*\/\* webpackIgnore: true \*\/\s*"\.\/scanic-mlDetector\.js"\s*\)/
+    );
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,13 @@ import { findCornerPoints } from './cornerDetection.js';
 import { cannyEdgeDetector, initializeWasm } from './edgeDetection.js';
 export { createCornerEditor } from './cornerEditor.js';
 
+// webpackIgnore keeps webpack apps from compiling the optional ML chunk (its
+// ORT bundle references the CDN-only ort.wasm.min.mjs and breaks their build).
+// Vite consumers are unaffected; guarded by src/distBundle.test.js.
+function importMlDetector() {
+  return import(/* webpackIgnore: true */ './mlDetector.js');
+}
+
 /**
  * Global initialization helper for convenience.
  */
@@ -47,7 +54,7 @@ export class Scanner {
     if (this.defaultOptions.detector === 'ml') {
       // Best-effort ML warm-up (lazy-loaded; never bundled into the classical path).
       try {
-        const { initializeMl } = await import('./mlDetector.js');
+        const { initializeMl } = await importMlDetector();
         await initializeMl(this.defaultOptions.ml || {});
       } catch {
         // ORT / assets unavailable. scan() will surface the error per-call.
@@ -1067,7 +1074,7 @@ export async function scanDocument(image, options = {}) {
     // Optional ML detector. Lazily imported so the classical build never bundles
     // onnxruntime-web or the model loader. Classical-only users pay zero bytes.
     t0 = performance.now();
-    const { detectDocumentMl } = await import('./mlDetector.js');
+    const { detectDocumentMl } = await importMlDetector();
     detection = await detectDocumentMl(image, options.ml || {});
     timings.push({ step: 'ML Detection Total', ms: (performance.now() - t0).toFixed(2) });
     if (detection.timings) detection.timings.forEach(t => timings.push(t));


### PR DESCRIPTION
Importing scanic's ESM entry currently breaks **webpack** builds (CRA, Next.js webpack mode), even for classical-only use:

```
Module not found: Error: Can't resolve 'ort.wasm.min.mjs' in '.../node_modules/scanic/dist'
```

Webpack statically follows `import('./mlDetector.js')` into the bundled ORT chunk, can't resolve the CDN-only `ort.wasm.min.mjs`, and the chunk's `import(expression)` additionally raises a critical-dependency warning (fatal under `CI=true`).

**Fix:** route both ML import sites through one loader carrying `/* webpackIgnore: true */`, keep that comment through terser (`format.comments`), and add `src/distBundle.test.js` so any toolchain change that strips it fails the release. Vite consumers are unchanged — the comment is inert there and chunking is identical.

**Verified:** `npm test` 46/46; a CRA 5 / webpack 5 app consuming the ESM entry goes from the error above to compiling clean with `CI=true`.

Note: webpack apps using `detector: 'ml'` now fail at runtime (chunk not emitted by their bundler) instead of failing the whole build. If you'd like ML to work there out of the box, a versioned-CDN fallback for the chunk would layer on top of this — happy to send that as a follow-up.
